### PR TITLE
allow people to use .then() or the already existing callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ webtorrentHealth(magnet, function (err, data) {
 })
 ```
 
+You can also use Promises/A+:
+
+```js
+var webtorrentHealth = require('webtorrent-health')
+var magnet = 'magnet:?xt=urn:btih:6a9759bffd5c0af65319979fb7832189f4f3c35d&dn=sintel.mp4&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com'
+
+webtorrentHealth(magnet).then(function (data) {
+  console.log('average number of seeders: ' + data.seeds)
+  console.log('average number of leechers: ' + data.peers)
+  console.log('ratio: ', +(Math.round((data.peers > 0 ? data.seeds / data.peers : data.seeds) +'e+2') + 'e-2'))
+}).catch(console.error.bind(console));
+```
+
 If you couldn't scrape any of the trackers you will not get any errors, but the returned data will look like this:
 
 ```js

--- a/index.js
+++ b/index.js
@@ -14,106 +14,112 @@ var TIMEOUT = 1000
  * @param {function} cb
  */
 var WebtorrentHealth = function (torrentId, opts, cb) {
-  if (!torrentId) throw new Error('A `torrentId` is required')
-  // At least two params
-  if (!opts) throw new Error('Second param missing')
-
-  if (typeof opts === 'function') {
-   // 'opts' can be 'cb'
-    cb = opts
-    opts = { trackers: [] }
-  } else if (typeof opts === 'object') {
-    // Use default values
-    if (!opts.trackers || !Array.isArray(opts.trackers)) opts.trackers = []
-    if (!opts.timeout || typeof opts.timeout !== 'number' || opts.timeout < 0) opts.timeout = TIMEOUT
-  } else {
-    throw new Error('Options type is invalid')
-  }
-
-  // Get info
-  var parsedTorrent
-  try {
-    parsedTorrent = parseTorrent(torrentId)
-  } catch (err) {}
-
-  if (!parsedTorrent) return cb(new Error('Invalid torrent file or magnet link'))
-
-  // Merge torrent trackers with custom ones into 'trackers' array
-  parsedTorrent.announce.forEach(function (tracker) {
-    if (opts.trackers.indexOf(tracker) === -1) opts.trackers.push(tracker)
-  })
-
-  if (opts.trackers.length === 0) return cb(new Error('No trackers found'))
-
-  var len = opts.trackers.length
-  var sumSeeds = 0
-  var sumPeers = 0
-  var total = 0
-  var aux = []
-  opts.trackers.forEach(function (tracker) {
-    // Send data function
-    var sendData = function () {
-      if (len === 0) {
-        // Dont divide by zero
-        if (total === 0) total = 1
-
-        // Return data
-        cb(null, {
-          seeds: Math.round(sumSeeds / total),
-          peers: Math.round(sumPeers / total),
-          extra: aux
-        })
+  return new Promise(function (resolve, reject) {
+    var callback = cb || opts;
+    if (!callback || typeof callback !== 'function') {
+      callback = function (err, data) {
+        if (err) return reject(err);
+        return resolve(data);
       }
     }
 
-    // Setup our own timeout
-    var canceled = false
-    var ms = opts.timeout || TIMEOUT
-    var timeout = setTimeout(function () {
-      canceled = true
-      timeout = null
-      len -= 1
-      // Save error
-      aux.push({
-        tracker: tracker,
-        error: 'Timed out'
-      })
-      // Last tracker
-      sendData()
-    }, ms)
+    if (!torrentId) return callback(new Error('A `torrentId` is required'))
 
-    var startTime = Date.now()
-    // Scrape tracker
-    ClientTracker.scrape({ announce: tracker, infoHash: parsedTorrent.infoHash, wrtc: true }, function (err, result) {
-      if (canceled) return
+    if (typeof opts === 'function' || !opts) {
+     // 'opts' can be 'cb'
+      cb = opts
+      opts = { trackers: [] }
+    } else if (typeof opts === 'object') {
+      // Use default values
+      if (!opts.trackers || !Array.isArray(opts.trackers)) opts.trackers = []
+      if (!opts.timeout || typeof opts.timeout !== 'number' || opts.timeout < 0) opts.timeout = TIMEOUT
+    }
 
-      clearTimeout(timeout)
-      len -= 1
+    // Get info
+    var parsedTorrent
+    try {
+      parsedTorrent = parseTorrent(torrentId)
+    } catch (err) {}
 
-      if (!err) {
-        // Sum data
-        sumSeeds += result.complete
-        sumPeers += result.incomplete
-        total++
+    if (!parsedTorrent) return callback(new Error('Invalid torrent file or magnet link'))
 
-        // Save data
-        aux.push({
-          tracker: result.announce,
-          seeds: result.complete,
-          peers: result.incomplete,
-          downloads: result.downloaded,
-          response_time: Date.now() - startTime
-        })
-      } else {
-        // Save client error
-        aux.push({
-          tracker: tracker,
-          error: err.message
-        })
+    // Merge torrent trackers with custom ones into 'trackers' array
+    parsedTorrent.announce.forEach(function (tracker) {
+      if (opts.trackers.indexOf(tracker) === -1) opts.trackers.push(tracker)
+    })
+
+    if (opts.trackers.length === 0) return callback(new Error('No trackers found'))
+
+    var len = opts.trackers.length
+    var sumSeeds = 0
+    var sumPeers = 0
+    var total = 0
+    var aux = []
+    opts.trackers.forEach(function (tracker) {
+      // Send data function
+      var sendData = function () {
+        if (len === 0) {
+          // Dont divide by zero
+          if (total === 0) total = 1
+
+          // Return data
+          callback(null, {
+            seeds: Math.round(sumSeeds / total),
+            peers: Math.round(sumPeers / total),
+            extra: aux
+          })
+        }
       }
 
-      // Last tracker
-      sendData()
+      // Setup our own timeout
+      var canceled = false
+      var ms = opts.timeout || TIMEOUT
+      var timeout = setTimeout(function () {
+        canceled = true
+        timeout = null
+        len -= 1
+        // Save error
+        aux.push({
+          tracker: tracker,
+          error: 'Timed out'
+        })
+        // Last tracker
+        sendData()
+      }, ms)
+
+      var startTime = Date.now()
+      // Scrape tracker
+      ClientTracker.scrape({ announce: tracker, infoHash: parsedTorrent.infoHash, wrtc: true }, function (err, result) {
+        if (canceled) return
+
+        clearTimeout(timeout)
+        len -= 1
+
+        if (!err) {
+          // Sum data
+          sumSeeds += result.complete
+          sumPeers += result.incomplete
+          total++
+
+          // Save data
+          aux.push({
+            tracker: result.announce,
+            seeds: result.complete,
+            peers: result.incomplete,
+            downloads: result.downloaded,
+            response_time: Date.now() - startTime
+          })
+        } else {
+          // Save client error
+          aux.push({
+            tracker: tracker,
+            error: err.message
+          })
+        }
+
+        // Last tracker
+        sendData()
+      })
     })
   })
 }


### PR DESCRIPTION
- remove the checks for an existing callback (afterall, if ppl don't want results, it shouldnt error, they just forgot to use the results)
- allow to use either `wbhealth(magnet, opts, function callback (err, data) {});` or `wbhealth(magnet, opts).then();`
- add docs